### PR TITLE
Modularize codebase and dockerize app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Optional — only needed if you want shareable result links.
+# Leave blank to run the app without sharing support.
+
+SUPABASE_URL=
+SUPABASE_KEY=

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,7 @@
+[server]
+headless = true
+port = 8501
+address = "0.0.0.0"
+
+[browser]
+gatherUsageStats = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONPATH=/app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app/
+COPY .streamlit/ ./.streamlit/
+
+EXPOSE 8501
+
+HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health || exit 1
+
+ENTRYPOINT ["streamlit", "run", "app/main.py"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,125 @@
 # Bandcamp Explorer
 
-A tool for exploring Bandcamp releases. 
+Discover music by exploring who bought a Bandcamp release — and what else they own.
 
-Try it out at: 🔗https://bc-explorer.app/
+Try it at: https://bc-explorer.app/
 
 ![Screenshot](https://bc-explorer.app/static/media/social.png)
+
+---
+
+## Running locally with Docker
+
+Docker lets you run the app without installing Python or any dependencies. Follow the guide for your operating system below.
+
+### Mac
+
+1. **Install Docker Desktop**
+   - Download from https://www.docker.com/products/docker-desktop/
+   - Open the `.dmg` file and drag Docker to your Applications folder
+   - Launch Docker from Applications and wait for the whale icon in your menu bar to stop animating
+
+2. **Download this project**
+   - Click the green **Code** button at the top of this page, then **Download ZIP**
+   - Unzip the folder somewhere easy to find (e.g. your Desktop)
+
+3. **Open a terminal in the project folder**
+   - Open **Terminal** (search for it with Spotlight: `Cmd + Space`, type "Terminal")
+   - Type `cd ` (with a space after), then drag the unzipped project folder into the Terminal window and press `Enter`
+
+4. **Create a config file**
+   ```
+   cp .env.example .env
+   ```
+
+5. **Start the app**
+   ```
+   docker compose up --build
+   ```
+   The first run downloads dependencies and may take a few minutes. When you see `You can now view your Streamlit app`, open http://localhost:8501 in your browser.
+
+6. **Stopping the app** — press `Ctrl + C` in the terminal, then run:
+   ```
+   docker compose down
+   ```
+
+---
+
+### Windows
+
+Docker on Windows works best through **WSL 2** (Windows Subsystem for Linux), which Docker Desktop sets up for you automatically.
+
+1. **Enable WSL 2** (skip if you already have it)
+   - Open **PowerShell as Administrator** (search "PowerShell" → right-click → *Run as administrator*)
+   - Run:
+     ```
+     wsl --install
+     ```
+   - Restart your computer when prompted
+
+2. **Install Docker Desktop**
+   - Download from https://www.docker.com/products/docker-desktop/
+   - Run the installer. When asked, make sure **"Use WSL 2 instead of Hyper-V"** is checked
+   - Restart if prompted, then launch Docker Desktop and wait for it to finish starting
+
+3. **Download this project**
+   - Click the green **Code** button at the top of this page, then **Download ZIP**
+   - Unzip the folder somewhere easy to find (e.g. your Desktop)
+
+4. **Open a terminal in the project folder**
+   - Open the unzipped project folder in File Explorer
+   - Click the address bar at the top, type `cmd`, and press `Enter` — this opens a command prompt in the right folder
+
+5. **Create a config file**
+   ```
+   copy .env.example .env
+   ```
+
+6. **Start the app**
+   ```
+   docker compose up --build
+   ```
+   The first run downloads dependencies and may take a few minutes. When you see `You can now view your Streamlit app`, open http://localhost:8501 in your browser.
+
+7. **Stopping the app** — press `Ctrl + C` in the terminal, then run:
+   ```
+   docker compose down
+   ```
+
+> **Troubleshooting:** If Docker Desktop says "WSL 2 installation is incomplete", open PowerShell as Administrator and run `wsl --update`, then restart Docker Desktop.
+
+---
+
+## Shareable URLs (optional)
+
+Results can be shared via `?id=` links if you connect a [Supabase](https://supabase.com) project. Create a table called `resultstable` with columns `uid` (text) and `data` (jsonb), then add your credentials to the `.env` file:
+
+```
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-anon-key
+```
+
+Without these the app works fully — you just can't generate shareable links.
+
+---
+
+## Running locally (for developers)
+
+```bash
+pip install -r requirements.txt
+PYTHONPATH=. streamlit run app/main.py
+```
+
+The app opens at http://localhost:8501.
+
+## Project structure
+
+```
+app/
+  main.py       # Streamlit entrypoint
+  scraper.py    # Async Bandcamp API/scraping
+  search.py     # Sidebar search
+  database.py   # Optional Supabase integration
+  ui.py         # Styles, HTML rendering
+  config.py     # Constants and env var loading
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bandcamp Explorer
 
+> **Huge shoutout to [roniqueh](https://github.com/roniqueh)** — the original creator of this tool. This project is built on their brilliant foundation. All credit for the core idea and initial implementation goes to them.
+
 Discover music by exploring who bought a Bandcamp release — and what else they own.
 
 Try it at: https://bc-explorer.app/

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,20 @@
+import os
+
+# Results
+MAX_RESULTS = 36
+
+# Bandcamp API
+FANS_ENDPOINT = "/api/tralbumcollectors/2/thumbs"
+COLLECTION_ENDPOINT = "https://bandcamp.com/api/fancollection/1/collection_items"
+BANDCAMP_SEARCH_URL = "https://bandcamp.com/search?q="
+COLLECTION_TOKEN = "2145916799::t"
+
+# UI defaults
+DEFAULT_BC_URL = "https://tobagotracks.bandcamp.com/album/fantasias-for-lock-in"
+WILDNESS_MAP = [18, 12, 9, 6, 4, 3, 2, 1]
+FRESHNESS_MAP = [1024, 512, 256, 128, 64, 32, 16, 8]
+
+# Supabase (optional — sharing feature disabled if not set)
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_KEY")
+SUPABASE_ENABLED = bool(SUPABASE_URL and SUPABASE_KEY)

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,34 @@
+from app.config import SUPABASE_ENABLED, SUPABASE_URL, SUPABASE_KEY
+
+_client = None
+
+
+def get_client():
+    global _client
+    if not SUPABASE_ENABLED:
+        return None
+    if _client is None:
+        from supabase import create_client
+        _client = create_client(SUPABASE_URL, SUPABASE_KEY)
+    return _client
+
+
+def load_shared_result(uid: str) -> dict | None:
+    """Load a previously shared result by UID. Returns None if DB unavailable or not found."""
+    client = get_client()
+    if client is None:
+        return None
+    row = client.table("resultstable").select("data").eq("uid", uid).limit(1).execute()
+    try:
+        return row.data[0]["data"]
+    except (IndexError, KeyError):
+        return None
+
+
+def save_result(uid: str, data: dict) -> bool:
+    """Save a result for sharing. Returns False if DB unavailable."""
+    client = get_client()
+    if client is None:
+        return False
+    client.table("resultstable").insert({"uid": uid, "data": data}).execute()
+    return True

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,201 @@
+import asyncio
+
+import streamlit as st
+from human_id import generate_id
+
+from app.config import DEFAULT_BC_URL, FRESHNESS_MAP, SUPABASE_ENABLED, WILDNESS_MAP
+from app.database import load_shared_result, save_result
+from app.scraper import InvalidBandcampURL, NoFansFound, discover
+from app.search import search_bandcamp
+from app.ui import apply_custom_styles, filter_tralbums_by_tag, render_bmc_button, render_results
+
+# ---------------------------------------------------------------------------
+# Page setup
+# ---------------------------------------------------------------------------
+
+st.set_page_config(page_title="Bandcamp Explorer")
+st.caption("[contact for bugs/suggestions :)](https://instagram.com/rxniqueh)")
+st.title("BANDCAMP EXPLORER")
+apply_custom_styles()
+render_bmc_button()
+
+# ---------------------------------------------------------------------------
+# Session state
+# ---------------------------------------------------------------------------
+
+_state_defaults = {
+    "bc_url_input": DEFAULT_BC_URL,
+    "submit_pressed": False,
+    "filter_pressed": False,
+    "query_params_loaded": False,
+    "results_dict": {
+        "uid": "",
+        "data": {"query_title": "", "query_url": "", "selected_tralbums": None},
+    },
+}
+for key, default in _state_defaults.items():
+    if key not in st.session_state:
+        st.session_state[key] = default
+
+# ---------------------------------------------------------------------------
+# Shared result loading (via ?id= query param + Supabase)
+# ---------------------------------------------------------------------------
+
+def _load_from_query_params():
+    uid = st.query_params.get("id")
+    if not uid or not SUPABASE_ENABLED:
+        return
+    data = load_shared_result(uid)
+    if data is not None:
+        st.session_state["results_dict"]["uid"] = uid
+        st.session_state["results_dict"]["data"].update(data)
+        st.session_state["submit_pressed"] = True
+        st.session_state["query_params_loaded"] = True
+        st.session_state["bc_url_input"] = data["query_url"]
+
+
+if not st.session_state["submit_pressed"] and not st.session_state["query_params_loaded"]:
+    _load_from_query_params()
+
+# ---------------------------------------------------------------------------
+# Callbacks
+# ---------------------------------------------------------------------------
+
+def _on_search_change():
+    st.session_state["submit_pressed"] = False
+    st.session_state["filter_pressed"] = False
+
+
+def _on_result_click(url: str):
+    st.session_state["submit_pressed"] = False
+    st.session_state["filter_pressed"] = False
+    st.session_state["bc_url_input"] = url
+
+# ---------------------------------------------------------------------------
+# Sidebar search
+# ---------------------------------------------------------------------------
+
+with st.sidebar:
+    query = st.text_input("bandcamp search", on_change=_on_search_change)
+    if query:
+        results = search_bandcamp(query)
+        if not results:
+            st.write("no results found, try something different")
+        for result in results:
+            st.button(
+                result["title"],
+                key=result["url"],
+                type="secondary",
+                on_click=_on_result_click,
+                args=(result["url"],),
+            )
+
+# ---------------------------------------------------------------------------
+# Input form
+# ---------------------------------------------------------------------------
+
+input_form = st.form("input_form")
+bc_url = input_form.text_input(
+    "what bandcamp release do you want to explore?",
+    help="url of bandcamp release (track or album)",
+    key="bc_url_input",
+    value=st.session_state["bc_url_input"],
+)
+input_form.caption("*p.s. mobile users: click arrow in top left for a search tool*")
+prioritise_recent = input_form.radio(
+    "prioritise recent purchasers?",
+    options=[False, True],
+    format_func=lambda v: "yes" if v else "no",
+    help="yes: recent purchasers of the release\n\nno: random purchasers of the release",
+) or False
+purchase_priority = input_form.radio(
+    "what would you like to prioritise in purchases?",
+    ("random", "recent", "top"),
+    help=(
+        "random: random purchases from the chosen purchasers\n\n"
+        "recent: recent purchases from the chosen purchasers\n\n"
+        "top: releases commonly found in purchasers' collections. "
+        "set wildness higher/freshness lower for better results."
+    ),
+)
+variability = WILDNESS_MAP[input_form.slider("wildness", 1, 8, 5, help="higher values looks at purchases from more users") - 1]
+freshness = FRESHNESS_MAP[input_form.slider("freshness", 1, 8, 5, help="higher values looks at more recent purchase histories of users") - 1]
+submitted = input_form.form_submit_button("submit")
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+
+if submitted and st.session_state["filter_pressed"]:
+    st.session_state["filter_pressed"] = False
+    st.session_state["results_dict"]["data"]["query_title"] = ""
+    st.session_state["results_dict"]["data"]["selected_tralbums"] = None
+
+if submitted and not st.session_state["filter_pressed"]:
+    st.session_state["submit_pressed"] = True
+    st.session_state["query_params_loaded"] = False
+    bc_url = st.session_state["bc_url_input"]
+
+    with st.spinner("hold on, goodness incoming :)"):
+        try:
+            selected_tralbums, query_title, query_url = asyncio.run(
+                discover(bc_url, prioritise_recent, purchase_priority, variability, freshness)
+            )
+        except InvalidBandcampURL:
+            st.warning(
+                "this needs to be a bandcamp release link. "
+                "to search releases and automatically input links, use the sidebar on the left"
+            )
+            st.stop()
+        except NoFansFound:
+            st.warning("nobody's bought this release :( try another one")
+            st.stop()
+
+    st.session_state["results_dict"]["data"]["selected_tralbums"] = selected_tralbums
+    st.session_state["results_dict"]["data"]["query_title"] = query_title
+    st.session_state["results_dict"]["data"]["query_url"] = query_url
+
+    if SUPABASE_ENABLED:
+        uid = generate_id()
+        st.session_state["results_dict"]["uid"] = uid
+        st.session_state["query_params_loaded"] = False
+        save_result(uid, st.session_state["results_dict"]["data"])
+
+# ---------------------------------------------------------------------------
+# Results display
+# ---------------------------------------------------------------------------
+
+if st.session_state["submit_pressed"] or st.session_state["filter_pressed"]:
+    results_dict = st.session_state["results_dict"]
+    query_title = results_dict["data"]["query_title"]
+    selected_tralbums = results_dict["data"]["selected_tralbums"]
+    query_url = results_dict["data"]["query_url"]
+
+    if SUPABASE_ENABLED and results_dict["uid"]:
+        st.query_params["id"] = results_dict["uid"]
+
+    purchasers = "recent" if prioritise_recent else "random"
+    if purchase_priority == "top":
+        subtitle = f"purchases commonly found in {purchasers} purchasers of [{query_title}]({query_url})"
+    else:
+        subtitle = f"{purchase_priority} purchases of {purchasers} purchasers of [{query_title}]({query_url})"
+    st.markdown(subtitle)
+
+    all_tags = sorted({tag for t in selected_tralbums for tag in t["tags"]})
+    filter_form = st.form("filter_form")
+    selected_tags = filter_form.multiselect("filter tags", all_tags)
+    filtered = filter_form.form_submit_button("filter")
+
+    if filtered:
+        st.session_state["filter_pressed"] = True
+        display_tralbums = filter_tralbums_by_tag(tuple(selected_tralbums), tuple(selected_tags))
+    else:
+        display_tralbums = selected_tralbums
+
+    render_results(display_tralbums)
+    st.session_state["query_params_loaded"] = True
+
+else:
+    st.session_state["submit_pressed"] = False
+    st.session_state["filter_pressed"] = False
+    st.stop()

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -1,0 +1,191 @@
+import asyncio
+import json
+import random
+import ssl
+from collections import Counter
+from datetime import datetime
+
+import aiohttp
+from aiohttp.client_exceptions import InvalidURL
+from bs4 import BeautifulSoup, SoupStrainer
+
+from app.config import (
+    COLLECTION_ENDPOINT,
+    COLLECTION_TOKEN,
+    FANS_ENDPOINT,
+    MAX_RESULTS,
+)
+
+
+class ScraperError(Exception):
+    pass
+
+
+class InvalidBandcampURL(ScraperError):
+    pass
+
+
+class NoFansFound(ScraperError):
+    pass
+
+
+def _create_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.set_alpn_protocols(["http/1.1"])
+    return ctx
+
+
+async def _get_tralbum_info(session: aiohttp.ClientSession, input_url: str) -> tuple:
+    """Fetch release metadata and purchaser list from a Bandcamp URL."""
+    try:
+        async with session.get(input_url) as resp:
+            soup_meta = BeautifulSoup(await resp.text(), "html.parser", parse_only=SoupStrainer("meta"))
+    except InvalidURL:
+        raise InvalidBandcampURL(input_url)
+
+    page_props_tag = soup_meta.find(attrs={"name": "bc-page-properties"})
+    if page_props_tag is None:
+        raise InvalidBandcampURL(input_url)
+
+    try:
+        bc_info = json.loads(page_props_tag["content"])
+    except (json.JSONDecodeError, KeyError):
+        raise InvalidBandcampURL(input_url)
+
+    url_main = input_url.split("://")[-1].split("/")[0]
+    fans_url = f"https://{url_main}{FANS_ENDPOINT}"
+    query_title = soup_meta.find(property="og:title")["content"]
+    query_tralbum_type = bc_info["item_type"]
+    query_tralbum_id = bc_info["item_id"]
+
+    payload = json.dumps({
+        "tralbum_type": query_tralbum_type,
+        "tralbum_id": str(query_tralbum_id),
+        "count": 500,
+    })
+    async with session.post(fans_url, data=payload) as resp:
+        parsed = await resp.json()
+
+    fans = [
+        {
+            "fan_id": item["fan_id"],
+            "mod_date": datetime.strptime(item["mod_date"], "%d %b %Y %H:%M:%S %Z"),
+        }
+        for item in parsed["results"]
+    ]
+
+    album_url = None
+    if query_tralbum_type == "t":
+        async with session.get(input_url) as resp:
+            soup_h3 = BeautifulSoup(await resp.text(), "html.parser", parse_only=SoupStrainer("h3"))
+            a_tag = soup_h3.find("a")
+            if a_tag:
+                album_url = f"https://{url_main}{a_tag['href']}"
+
+    return query_title, query_tralbum_type, query_tralbum_id, fans, album_url
+
+
+async def _get_fan_tralbums(
+    session: aiohttp.ClientSession,
+    fan_id: int,
+    freshness: int,
+    purchase_priority: str,
+    query_tralbum_id: int,
+    tralbums_per_fan: int,
+) -> list:
+    payload = json.dumps({
+        "fan_id": fan_id,
+        "older_than_token": COLLECTION_TOKEN,
+        "count": freshness,
+    })
+    async with session.post(COLLECTION_ENDPOINT, data=payload) as resp:
+        parsed = await resp.json()
+
+    desired_keys = (
+        "item_type", "tralbum_id", "item_url", "item_title",
+        "band_name", "num_streamable_tracks", "is_subscriber_only",
+    )
+    tralbums = [
+        {key: item[key] for key in desired_keys}
+        for item in parsed["items"]
+    ]
+    tralbums = [
+        t for t in tralbums
+        if t["tralbum_id"] != query_tralbum_id
+        and t["num_streamable_tracks"] != 0
+        and not t["is_subscriber_only"]
+    ]
+
+    if purchase_priority == "top":
+        return tralbums
+    if purchase_priority == "recent":
+        return tralbums[:tralbums_per_fan]
+    return random.sample(tralbums, min(tralbums_per_fan, len(tralbums)))
+
+
+async def _get_tralbum_tags(session: aiohttp.ClientSession, item_url: str) -> list:
+    try:
+        async with session.get(item_url) as resp:
+            soup = BeautifulSoup(await resp.text(), "html.parser", parse_only=SoupStrainer("a"))
+            return [item.text for item in soup.find_all(class_="tag")]
+    except Exception:
+        return []
+
+
+async def discover(
+    bc_url: str,
+    prioritise_recent: bool,
+    purchase_priority: str,
+    variability: int,
+    freshness: int,
+) -> tuple[list, str, str]:
+    """Main entry point: discover related releases for a Bandcamp URL."""
+    ssl_context = _create_ssl_context()
+    connector = aiohttp.TCPConnector(ssl=ssl_context)
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        query_url = bc_url
+        query_title, tralbum_type, tralbum_id, fans, album_url = await _get_tralbum_info(session, bc_url)
+
+        if not fans:
+            if tralbum_type == "t" and album_url:
+                query_title, tralbum_type, tralbum_id, fans, _ = await _get_tralbum_info(session, album_url)
+                if fans:
+                    query_url = album_url
+                else:
+                    raise NoFansFound(bc_url)
+            else:
+                raise NoFansFound(bc_url)
+
+        fan_count = MAX_RESULTS // variability
+        if prioritise_recent:
+            selected_fans = fans[:fan_count]
+        else:
+            selected_fans = random.sample(fans, min(fan_count, len(fans)))
+
+        tralbums_per_fan = MAX_RESULTS // len(selected_fans)
+
+        tasks = [
+            _get_fan_tralbums(session, fan["fan_id"], freshness, purchase_priority, tralbum_id, tralbums_per_fan)
+            for fan in selected_fans
+        ]
+        fan_tralbums = await asyncio.gather(*tasks)
+        all_tralbums = [item for sublist in fan_tralbums for item in sublist]
+
+        if purchase_priority == "top":
+            most_common = Counter(t["tralbum_id"] for t in all_tralbums).most_common(MAX_RESULTS)
+            top_ids = {item[0] for item in most_common}
+            seen = set()
+            deduped = []
+            for t in all_tralbums:
+                if t["tralbum_id"] in top_ids and t["tralbum_id"] not in seen:
+                    deduped.append(t)
+                    seen.add(t["tralbum_id"])
+            all_tralbums = deduped
+
+        tag_tasks = [_get_tralbum_tags(session, t["item_url"]) for t in all_tralbums]
+        tags_per_tralbum = await asyncio.gather(*tag_tasks)
+        for tralbum, tags in zip(all_tralbums, tags_per_tralbum):
+            tralbum["tags"] = tags
+
+        return all_tralbums, query_title, query_url

--- a/app/search.py
+++ b/app/search.py
@@ -1,0 +1,68 @@
+import json
+
+import requests
+from bs4 import BeautifulSoup, SoupStrainer
+
+from app.config import BANDCAMP_SEARCH_URL
+
+_session = requests.Session()
+
+_URL_ENCODE = str.maketrans({
+    "+": "%2B",
+    " ": "+",
+    "&": "%26",
+    "=": "%3D",
+    "@": "%40",
+    "'": "%27",
+})
+
+
+def search_bandcamp(query: str) -> list:
+    """Search Bandcamp and return a list of album/track results."""
+    encoded = query.translate(_URL_ENCODE)
+    try:
+        response = _session.get(BANDCAMP_SEARCH_URL + encoded, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException:
+        return []
+
+    soup = BeautifulSoup(response.text, "html.parser", parse_only=SoupStrainer("li"))
+    results = soup.find_all(class_="searchresult data-search")
+
+    output = []
+    for item in results:
+        try:
+            summary = json.loads(item["data-search"])
+        except (KeyError, json.JSONDecodeError, ValueError):
+            try:
+                import ast
+                summary = ast.literal_eval(item["data-search"])
+            except Exception:
+                continue
+
+        if summary.get("type") not in ("a", "t"):
+            continue
+
+        result_info = item.find(class_="result-info")
+        if not result_info:
+            continue
+
+        heading = result_info.find(class_="heading")
+        subhead = result_info.find(class_="subhead")
+        if not heading:
+            continue
+
+        title = "**{}** *{}*".format(
+            heading.get_text(strip=True),
+            " ".join(w for w in subhead.get_text(strip=True).replace("\n", "").split(" ") if w)
+            if subhead else "",
+        )
+
+        a_tag = item.find("a")
+        if not a_tag:
+            continue
+
+        url = a_tag["href"].split("?")[0]
+        output.append({"url": url, "title": title})
+
+    return output

--- a/app/ui.py
+++ b/app/ui.py
@@ -1,0 +1,122 @@
+import streamlit as st
+from streamlit.components.v1 import html
+
+CUSTOM_CSS = """
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;700&display=swap');
+
+html, body, div, label [class*="css"]  {
+font-family: 'Syne', sans-serif;
+}
+
+section.main {
+background-color:hsla(15,100%,80%,0);
+background-image:
+url("https://www.transparenttextures.com/patterns/otis-redding.png"),
+radial-gradient(at 55% 17%, hsla(43,71%,37%,1) 0px, transparent 50%),
+radial-gradient(at 27% 78%, hsla(187,71%,37%,1) 0px, transparent 50%),
+radial-gradient(at 94% 10%, hsla(24,71%,37%,1) 0px, transparent 50%),
+radial-gradient(at 21% 1%, hsla(332,71%,37%,1) 0px, transparent 50%),
+radial-gradient(at 7% 96%, hsla(183,71%,37%,1) 0px, transparent 50%),
+radial-gradient(at 95% 32%, hsla(263,71%,37%,1) 0px, transparent 50%),
+radial-gradient(at 53% 81%, hsla(33,71%,37%,1) 0px, transparent 50%);
+}
+
+.block-container {
+padding-top: 2rem;
+}
+
+div[data-testid="stCaptionContainer"] {
+text-align: right;
+}
+
+div[data-testid="stForm"] {
+background-color: rgba(0, 0, 0, .10);
+backdrop-filter: blur(16px);
+}
+
+h1 {
+font-weight:700;
+font-size:3rem;
+}
+
+section[data-testid="stSidebar"] div.stButton button {
+width: 100%;
+}
+
+div[data-testid="stToolbar"] {
+visibility: hidden;
+height: 0%;
+position: fixed;
+}
+
+div[data-testid="stDecoration"] {
+visibility: hidden;
+height: 0%;
+position: fixed;
+}
+div[data-testid="stStatusWidget"] {
+visibility: hidden;
+height: 0%;
+position: fixed;
+}
+#MainMenu {
+visibility: hidden;
+height: 0%;
+}
+header {
+visibility: hidden;
+height: 0%;
+}
+footer {
+visibility: hidden;
+height: 0%;
+}
+</style>
+"""
+
+BMC_BUTTON_HTML = """
+<script type="text/javascript"
+    src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+    data-name="bmc-button"
+    data-slug="bc.explorer"
+    data-color="#FFDD00"
+    data-emoji=""
+    data-font="Cookie"
+    data-text="Buy me a coffee"
+    data-outline-color="#000000"
+    data-font-color="#000000"
+    data-coffee-color="#000000" >
+</script>
+"""
+
+
+def apply_custom_styles():
+    st.markdown(CUSTOM_CSS, unsafe_allow_html=True)
+
+
+def render_bmc_button():
+    html(BMC_BUTTON_HTML, width=220, height=84)
+
+
+def render_results(tralbums: list) -> None:
+    html_list = []
+    for tralbum in tralbums:
+        item_type = 'album' if tralbum['item_type'] == 'package' else tralbum['item_type']
+        html_list.append(
+            f'<iframe style="border: 0; width: 200px; height: 200px;" '
+            f'src="https://bandcamp.com/EmbeddedPlayer/{item_type}={tralbum["tralbum_id"]}'
+            f'/size=large/bgcol=333333/linkcol=0f91ff/minimal=true/transparent=true/" seamless>'
+            f'<a href={tralbum["item_url"]}>{tralbum["item_title"]} by {tralbum["band_name"]}</a>'
+            f'</iframe>'
+        )
+    html_insert = '<div class="results-container" style="text-align: center;">\n' + "\n".join(html_list) + '\n</div>'
+    st.markdown(html_insert, unsafe_allow_html=True)
+
+
+@st.cache_data(max_entries=50)
+def filter_tralbums_by_tag(selected_tralbums: tuple, selected_tags: tuple) -> list:
+    """Filter tralbums by tags. Accepts tuples for hashability with st.cache_data."""
+    if not selected_tags:
+        return list(selected_tralbums)
+    return [t for t in selected_tralbums if set(t['tags']).intersection(selected_tags)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  bc-explorer:
+    build: .
+    ports:
+      - "8501:8501"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "bc-explorer"
+version = "0.1.0"
+description = "Discover music by exploring who bought a Bandcamp release — and what else they own."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "streamlit>=1.32.0",
+    "requests>=2.31.0",
+    "beautifulsoup4>=4.12.0",
+    "aiohttp>=3.9.0",
+    "human-id>=0.2.0",
+    "supabase>=2.0.0",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-requests~=2.27.1
-beautifulsoup4~=4.11.1
-aiohttp~=3.8.1
-streamlit~=1.17.0
-pandas~=1.4.2
-numpy==1.26.4
-supabase~=0.7.1
-human-id~=0.2.0
-altair<5
+streamlit>=1.32.0
+requests>=2.31.0
+beautifulsoup4>=4.12.0
+aiohttp>=3.9.0
+human-id>=0.2.0
+supabase>=2.0.0


### PR DESCRIPTION
## Summary

Refactors the original single-file `st_bc_explorer.py` into a clean, maintainable module structure under an `app/` package, and adds full Docker support for self-hosting.

## New directory structure

The app logic is now split into focused modules:

    app/
    ├── __init__.py
    ├── config.py     # Constants, env vars, and feature flags (Supabase, API endpoints, etc.)
    ├── database.py   # Supabase client initialization and shared result persistence
    ├── scraper.py    # Async Bandcamp scraping logic (fan discovery, album data)
    ├── search.py     # Bandcamp search functionality
    ├── ui.py         # Streamlit UI components, custom CSS, and rendering helpers
    └── main.py       # App entrypoint — wires everything together

## Docker support

A `Dockerfile` and `docker-compose.yml` are added for easy self-hosting:
- Built on `python:3.12-slim`
- Exposes port `8501` with a health check against the Streamlit health endpoint
- Loads environment variables from `.env` via `docker-compose`
- A `.env.example` is included to document required environment variables

## Other changes

- `pyproject.toml` added for modern Python packaging
- `.streamlit/config.toml` added for Streamlit server configuration
- `requirements.txt` cleaned up
- `README.md` significantly expanded with setup, usage, and Docker instructions
